### PR TITLE
The return value of EnclaveInterface::initialize is not assigned

### DIFF
--- a/src/p11/untrusted/GPFunctions.cpp
+++ b/src/p11/untrusted/GPFunctions.cpp
@@ -91,7 +91,7 @@ CK_RV initialize(CK_VOID_PTR pInitArgs)
 
     if (EnclaveInterface::loadEnclave())
     {
-        rv == EnclaveInterface::initialize(pInitArgs);
+        rv = EnclaveInterface::initialize(pInitArgs);
 
         if(CKR_OK == rv)
         {


### PR DESCRIPTION
Use assignment instead of equality comparison