### PR TITLE
Do not automatically use testing key for enclave signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ After downloading the souce, run ``sh autogen.sh``
 ### Configuration options
 The source can be configured by running ``./configure``
 
-``$ ./configure``
+``$ ./configure --with-enclave-signing-key=src/p11/enclave_config/p11Enclave_private.pem``
+
+> **NOTE** Please note that the enclave in the above example is signed with a test signing key. A production enclave should go through the process of signing an enclave as explained in the section Enclave Signing Tool in the [Intel(R) SGX Developer Reference for Linux* OS](https://download.01.org/intel-sgx/latest/linux-latest/docs/).
 
 The options that ``configure`` supports can be obtained by running ``./configure --help``. Below are the options that are specific to CTK:
 
@@ -92,11 +94,10 @@ The options that ``configure`` supports can be obtained by running ``./configure
 |--with-p11-kit-path | p11-kit include directory path | Build without p11-kit, using PKCS11 headers from CTK |
 |--enable-mitigation | Enable mitigations for CVE-2020-0551 (LVI) and other vulnerabilities | Mitigations disabled for CVE-2020-0551 (LVI) and other vulnerabilities |
 |--disable-multiprocess-support | If the token is not expected to be simultaneously accessed for modification by multiple processes (write/update/delete), this flag can give a performance boost. | The token and the objects are allowed to be modified (write/update/delete) by multiple processes simultaneously.
+|--with-enclave-signing-key | Sign enclave with given signing key | Do not sign the enclave |
 
 ### Compiling
 ``$ make``
-
-> **NOTE** Please note that the enclave is signed with a test signing key. A production enclave should go through the process of signing an enclave as explained in the section Enclave Signing Tool in the [Intel(R) SGX Developer Reference for Linux* OS](https://download.01.org/intel-sgx/latest/linux-latest/docs/).
 
 ### Installation
 ``$ sudo make install``

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,11 @@ AC_ARG_WITH([p11-kit-path],
             [P11KITINCLUDEPATH="${withval}"],
             [echo "--with-p11-kit-path option not set. Not including PKCS11 headers from p11-kit."; P11KITINCLUDEPATH="no"])
 
+AC_ARG_WITH([enclave-signing-key],
+            AC_HELP_STRING([--with-enclave-signing-key], [Will default to no signing key.]),
+            [SIGNINGKEYPATH="${withval}"],
+            [echo "--with-enclave-signing-key option not set. Not signing the enclave."; SIGNINGKEYPATH=""])
+
 AM_CONDITIONAL(WITH_DCAP, false)
 
 AC_ARG_ENABLE([dcap],
@@ -111,9 +116,15 @@ AC_ARG_ENABLE([multiprocess-support],
               [AC_DEFINE([MULTIPROCESS_SUPPORT_DISABLED], [], [MULTIPROCESS SUPPORT DISABLED])],
               [echo "--disable-multiprocess-support option not set. If the token is not expected to be simultaneously accessed for modification by multiple processes (write/update/delete), this flag can give a performance boost."])
 
+AM_CONDITIONAL(NO_SIGNING, false)
+AS_IF([test "x$SIGNINGKEYPATH" = "x"],
+      AM_CONDITIONAL(NO_SIGNING, true),
+      AC_CHECK_FILE("$SIGNINGKEYPATH", AC_SUBST(SIGNINGKEYPATH, $(realpath $SIGNINGKEYPATH)),[AC_MSG_ERROR([Enclave signing key configured but not found])]))
+
 AC_SUBST(SGXSDKDIR, $SGXSDK)
 AC_SUBST(SGXSSLDIR, $SGXSSL)
 AC_SUBST(CATKTOKENPATH, $TOKENPATH)
+AC_SUBST(SIGNINGKEYPATH, $SIGNINGKEYPATH)
 
 AC_PATH_PROG([SGX_EDGER8R], sgx_edger8r, [:], [${SGXSDKDIR}/bin/x64])
 

--- a/src/p11/trusted/Makefile.am
+++ b/src/p11/trusted/Makefile.am
@@ -52,6 +52,17 @@ else
 SGXSSLLIBDIR = $(SGXSSLDIR)/lib64
 endif
 
+if NO_SIGNING
+all-local: libp11SgxEnclave.la
+
+install-exec-local:
+else
+all-local: libp11SgxEnclave.la libp11SgxEnclave.signed.so
+
+install-exec-local:
+	cp .libs/libp11SgxEnclave.signed.so $(prefix)/lib
+endif
+
 EXTRA_DIST = $(srcdir)/../enclave_config/*        \
              $(srcdir)/*.h                        \
              $(srcdir)/SoftHSMv2/*.h              \
@@ -82,7 +93,11 @@ p11Enclave_t.h: p11Enclave_t.c
 p11Enclave_t.c: $(SGX_EDGER8R) ../enclave_config/p11Enclave.edl
 	$(SGX_EDGER8R) --trusted p11Enclave.edl --search-path $(srcdir)/../../../ --search-path $(srcdir)/../enclave_config --search-path $(SGXSDKDIR)/include --search-path $(SGXSSLDIR)/include
 
-all-local: libp11SgxEnclave.la
+libp11SgxEnclave.signed.so: libp11SgxEnclave.so
+	@$(SGX_SIGN) sign -key $(SIGNINGKEYPATH) -enclave ./.libs/libp11SgxEnclave.so.0.0.0 -out ./.libs/libp11SgxEnclave.signed.so -config $(srcdir)/../enclave_config/p11Enclave.config.xml
+	@echo "--------------------libp11SgxEnclave.signed.so built-----------------------------"
+
+libp11SgxEnclave.so: libp11SgxEnclave.la
 	@echo "--------------------libp11SgxEnclave.la built-----------------------------"
 #   this is a workaround to relink the enclave because the linker flags for the enclave are not handled properly by libtool
 #	ls -laR ./.libs/
@@ -165,11 +180,7 @@ all-local: libp11SgxEnclave.la
 		   ./SoftHSMv2/session_mgr/SessionManager.o                     \
 		   ./SoftHSMv2/P11Attributes.o                                  \
 		   -m64 -Wall -O2 -D_FORTIFY_SOURCE=2 -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -pie -L$(SGXSSLLIBDIR) -Wl,--whole-archive -lsgx_tsgxssl -Wl,--no-whole-archive -lsgx_tsgxssl_crypto -L$(SGXSDKDIR)/lib64 -Wl,--whole-archive -lsgx_trts -Wl,--no-whole-archive -Wl,--start-group -lsgx_tstdc -lsgx_tcxx -lsgx_tcrypto -lsgx_tservice -lsgx_tprotected_fs -lsgx_pthread -Wl,--end-group -Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined -Wl,-pie,-eenclave_entry -Wl,--export-dynamic -Wl,--defsym,__ImageBase=0 -Wpragmas -Wl,-soname -Wl,libp11SgxEnclave.so.0 -o .libs/libp11SgxEnclave.so.0.0.0
-		@$(SGX_SIGN) sign -key $(srcdir)/../enclave_config/p11Enclave_private.pem -enclave ./.libs/libp11SgxEnclave.so.0.0.0 -out ./.libs/libp11SgxEnclave.signed.so -config $(srcdir)/../enclave_config/p11Enclave.config.xml
-		@echo "--------------------libp11SgxEnclave.signed.so built-----------------------------"
-
-install-exec-local:
-	cp .libs/libp11SgxEnclave.signed.so $(prefix)/lib
+	@echo "--------------------libp11SgxEnclave.so built-----------------------------"
 
 uninstall-local:
 	rm -f $(prefix)/lib/libp11SgxEnclave.signed.so* \


### PR DESCRIPTION
Add a new `./configure` parameter `--with-enclave-signing-key` which points to the private key that is used for signing the enclave. The idea is to not sign the enclave with the test key by default, for reasons listed in #4 . The documentation is updated to reflect this change. The old behavior of

    ./configure

can be reproduced with

     ./configure --with-enclave-signing-key=src/p11/enclave_config/p11Enclave_private.pem

Later, the plan is to remove testing key fully from the repository and instead give instructions for the user to recreate it (if needed).