### PR TITLE
Fix build by adding an include.

### DIFF
--- a/src/p11/untrusted/EnclaveHelpers.h
+++ b/src/p11/untrusted/EnclaveHelpers.h
@@ -66,6 +66,7 @@
 #include <sgx_urts.h>
 #include <sgx_error.h>
 #include <map>
+#include <string>
 #include <unistd.h>
 
 #include "p11Enclave_u.h"


### PR DESCRIPTION
The build is broken for me (Fedora 35 / `g++ (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)`). Add a missing include to fix it.

    In file included from EnclaveInterface.cpp:33:
    EnclaveHelpers.h:74:19: error: ‘string’ in namespace ‘std’ does not name a type
       74 | static const std::string toolkitPath        = CRYPTOTOOLKIT_TOKENPATH;
          |                   ^~~~~~
    EnclaveHelpers.h:72:1: note: ‘std::string’ is defined in header ‘<string>’; did you forget to ‘#include <string>’?