### PR TITLE
Fix bug in getRSAPairKey

### DIFF
--- a/src/p11/trusted/SoftHSMv2/SoftHSM.cpp
+++ b/src/p11/trusted/SoftHSMv2/SoftHSM.cpp
@@ -15316,6 +15316,7 @@ CK_OBJECT_HANDLE SoftHSM::getRSAPairKey(const CK_SESSION_HANDLE& hSession,
         rv = FindObjectsInit(hSession, &pTemplate[0], 1);
         if (CKR_OK != rv)
         {
+            C_FindObjectsFinal(hSession);
             return rsaPairKeyHandle;
         }
 
@@ -15325,6 +15326,7 @@ CK_OBJECT_HANDLE SoftHSM::getRSAPairKey(const CK_SESSION_HANDLE& hSession,
         rv = FindObjects(hSession, &hObjects[0], 2, &ulObjectCount);
         if (CKR_OK != rv || 2 != ulObjectCount)
         {
+            C_FindObjectsFinal(hSession);
             return rsaPairKeyHandle;
         }
 


### PR DESCRIPTION
Added missing calls to C_FindObjectsFinal before returning from getRSAPairKey. Not having these two calls before return led to issue next time calling C_FindObjectsInit.